### PR TITLE
Update reference.md

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -58,6 +58,7 @@ For some endpoints, you will have to Bring Your Own UUID (BYOU). Worry not - thi
 | [uuid.uuidv4()](https://www.npmjs.com/package/uuid)                    | JavaScript |
 | [uuid-random.uuid()](https://www.npmjs.com/package/uuid-random)        | JavaScript |
 | System.Guid.NewGuid()                                                  |     C#     |
+| [Uuid::new_v4](https://docs.rs/uuid/0.8.2/uuid/struct.Uuid.html#method.new_v4) | Rust |
 
 ## Generic Object IDs
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -58,7 +58,7 @@ For some endpoints, you will have to Bring Your Own UUID (BYOU). Worry not - thi
 | [uuid.uuidv4()](https://www.npmjs.com/package/uuid)                    | JavaScript |
 | [uuid-random.uuid()](https://www.npmjs.com/package/uuid-random)        | JavaScript |
 | System.Guid.NewGuid()                                                  |     C#     |
-| [Uuid::new_v4](https://docs.rs/uuid/0.8.2/uuid/struct.Uuid.html#method.new_v4) | Rust |
+| [Uuid::new_v4()](https://docs.rs/uuid/0.8.2/uuid/struct.Uuid.html#method.new_v4) | Rust |
 
 ## Generic Object IDs
 


### PR DESCRIPTION
Add `Uuid::new_v4` UUID generation function for the Rust programming language in the table of functions for generating UUIDs.