### PR TITLE
Fix vagueness with get channel messages

### DIFF
--- a/docs/resources/channel.md
+++ b/docs/resources/channel.md
@@ -651,7 +651,7 @@ Delete a channel. Deleting a category does not delete its child channels; they w
 ## Get Channel Messages
 <span class="http-verb">GET</span><span class="http-path">/channels/{[channel.id](/resources/channel#channel-object)}/messages</span>
 
-Returns the messages for a channel. Does not require authentication. Returns an array of [message](/resources/channel#message-object) objects and a boolean `hasPastMessages` detailing if there are messages preceeding this array on success.
+Returns the messages for a channel. Does not require authentication if a channel is public. Returns an array of [message](/resources/channel#message-object) objects and a boolean `hasPastMessages` detailing if there are messages preceeding this array on success.
 
 Query string parameter `limit` has been tested up to 50,000.
 


### PR DESCRIPTION
Someone thought you can get private channel messages without authentication due to it being a bit vague.