### PR TITLE
Document `beforeDate` and `afterDate` for Get Channel Messages

### DIFF
--- a/docs/resources/channel.md
+++ b/docs/resources/channel.md
@@ -654,13 +654,15 @@ Delete a channel. Deleting a category does not delete its child channels; they w
 
 Returns the messages for a channel. Does not require authentication. Returns an array of [message](/resources/channel#message-object) objects and a boolean `hasPastMessages` detailing if there are messages preceeding this array on success.
 
-Query string parameter `limit` has been tested up to 50,000.
+Query string parameter `limit` is interpreted as a bigint value and therefore can be as high as 2^63. Anything over this value will quickly return a 500 error code.
 
 ###### Query String Params
 
 | Field  | Type    | Description                              | Required | Default |
 |--------|---------|------------------------------------------|----------|---------|
-| limit  | integer | max number of messages to return (0-???) | false    | 51      |
+| limit  | integer | max number of messages to return (0-2^63) | false    | 51      |
+| beforeDate | timestamp | filters messages by those made before a certain timestamp | false | now |
+| afterDate | timestamp | filters messages by those made after a certain timestamp | false | epoch? |
 
 ## Get Channel Message
 <span class="http-verb">GET</span><span class="http-path">/content/route/metadata?route=//channels/{[channel.id](/resources/channel#channel-object)}/chat?messageId={[message.id](/resources/channel#message-object)}</span>

--- a/docs/resources/channel.md
+++ b/docs/resources/channel.md
@@ -654,15 +654,15 @@ Delete a channel. Deleting a category does not delete its child channels; they w
 
 Returns the messages for a channel. Does not require authentication. Returns an array of [message](/resources/channel#message-object) objects and a boolean `hasPastMessages` detailing if there are messages preceeding this array on success.
 
-Query string parameter `limit` is interpreted as a bigint value and therefore can be as high as 2^63. Anything over this value will quickly return a 500 error code.
-
 ###### Query String Params
 
-| Field  | Type    | Description                              | Required | Default |
-|--------|---------|------------------------------------------|----------|---------|
-| limit  | integer | max number of messages to return (0-2^63) | false    | 51      |
-| beforeDate | timestamp | filters messages by those made before a certain timestamp | false | now |
-| afterDate | timestamp | filters messages by those made after a certain timestamp | false | epoch? |
+| Field      | Type              | Description                                               | Required | Default |
+|------------|-------------------|-----------------------------------------------------------|----------|---------|
+| limit      | integer           | max number of messages to return (0-2^63)\*               | false    | 51      |
+| beforeDate | ISO8601 timestamp | filters messages by those made before a certain timestamp | false    | now     |
+| afterDate  | ISO8601 timestamp | filters messages by those made after a certain timestamp  | false    | epoch?  |
+
+\* `limit` is interpreted as a bigint value and therefore can be as high as 2^63. Anything over this value will quickly return a 500 error code.
 
 ## Get Channel Message
 <span class="http-verb">GET</span><span class="http-path">/content/route/metadata?route=//channels/{[channel.id](/resources/channel#channel-object)}/chat?messageId={[message.id](/resources/channel#message-object)}</span>


### PR DESCRIPTION
I noticed two common query parameters (`beforeDate` and `afterDate`) for this endpoint were missing, so I added them. I also have done some testing with the `limit` parameter and found that it is restricted to a maximum of 2^63 (although, practically speaking, a request of that sort will never be completed). It is worth mentioning that all of these things match up with PostgreSQL's spec. Correct me if I'm wrong, but MySQL's timestamps are limited to after Unix epoch. I found this was not the case with Guilded. The lower limit is 0001-01-01 inclusive. Additionally, the upper limit is the same as PostgreSQL's of 294276-12-31, not 9999-12-31 like some other implementations (Oracle). Going outside these bounds, as is the case with `limit` and its barriers, causes an internal server error.

