### PR TITLE
chore: remove unmaintained/insufficient content library resources

### DIFF
--- a/docs/topics/community-resources.md
+++ b/docs/topics/community-resources.md
@@ -11,7 +11,6 @@ Many of these libraries are represented in the [community-driven server for deve
 | Name                                                       | Language   | API Support        |
 | ---------------------------------------------------------- | ---------- | ------------------ |
 | [Gdd.js](https://github.com/RemyK888/gdd.js/)              | TypeScript | Official\*         |
-| [Guild.js](https://github.com/Guild-js/guild.js)           | JavaScript | Official\*         |
 | [GuildScript](https://github.com/GuildScript/GuildScript)  | JavaScript | Client             |
 | [Guilded.NET](https://github.com/Guilded-NET/Guilded.NET)  | C#         | Official\*         |
 | [Guilded4J](https://github.com/MCUmbrella/Guilded4J)       | Java       | Official\*         |

--- a/docs/topics/community-resources.md
+++ b/docs/topics/community-resources.md
@@ -11,12 +11,11 @@ Many of these libraries are represented in the [community-driven server for deve
 | Name                                                       | Language   | API Support        |
 | ---------------------------------------------------------- | ---------- | ------------------ |
 | [Gdd.js](https://github.com/RemyK888/gdd.js/)              | TypeScript | Official\*         |
-| [GuildScript](https://github.com/GuildScript/GuildScript)  | JavaScript | Client             |
 | [Guilded.NET](https://github.com/Guilded-NET/Guilded.NET)  | C#         | Official\*         |
 | [Guilded4J](https://github.com/MCUmbrella/Guilded4J)       | Java       | Official\*         |
 | [Guildedeno](https://github.com/Scientific-Guy/guildedeno) | Deno       | Client             |
 | [gapi](https://github.com/Skillz4Killz/gapi)               | TypeScript | Client             |
-| [guilded.js](https://github.com/zaida04/guilded.js)        | JavaScript | Client             |
+| [guilded.js](https://github.com/zaida04/guilded.js)        | JavaScript | Client, Official\* |
 | [guilded.py](https://github.com/shayypy/guilded.py)        | Python     | Client, Official\* |
 | [deck](https://github.com/SrGaabriel/deck)                 | Kotlin     | Client             |
 


### PR DESCRIPTION
[Guild.js](https://github.com/Guild-js/guild.js) - Does not have sufficient content
[GuildScript](https://github.com/GuildScript/GuildScript) - Last commit was 8 months ago, has not adapted to the WebSocket break requiring guilded_mids in connection URL.