### PR TITLE
docs: add `Guildeno` to community resources

### DIFF
--- a/docs/topics/community-resources.md
+++ b/docs/topics/community-resources.md
@@ -18,6 +18,7 @@ Many of these libraries have dedicated groups in the [community API server](http
 | [Guilded.TS](https://github.com/guildedts/guilded.ts)      | TypeScript | Official\*         |
 | [Guilded4J](https://github.com/MCUmbrella/Guilded4J)       | Java       | Official\*         |
 | [Guildedeno](https://github.com/Scientific-Guy/guildedeno) | Deno       | Client             |
+| [Guildeno](https://github.com/guildeno/guildeno)           | TypeScript | Official\*         |
 
 \* The official API is currently in early access, so you will need explicit approval from a Guilded staff member to use it, and by extension, the libraries that wrap it.
 


### PR DESCRIPTION
Hey, I have created yet another lib for the Guilded API. I'm still actively working on it, but I thought it would be nice to list it here already .-.

- [x] `retry-after` is taken into account when it is provided 
- [x] 100% API coverage as of now
- [x] There isn't really anything to abstract with the (in future) public API imho.