### PR TITLE
Make library name casing more consistent

### DIFF
--- a/docs/topics/community-resources.md
+++ b/docs/topics/community-resources.md
@@ -10,11 +10,11 @@ Many of these libraries have dedicated groups in the [community API server](http
 
 | Name                                                       | Language   | API Support        |
 | ---------------------------------------------------------- | ---------- | ------------------ |
-| [deck](https://github.com/SrGaabriel/deck)                 | Kotlin     | Client             |
+| [Deck](https://github.com/SrGaabriel/deck)                 | Kotlin     | Client             |
 | [Gdd.js](https://github.com/RemyK888/gdd.js)               | TypeScript | Official\*         |
-| [guilded.js](https://github.com/guildedjs/guilded.js)      | JavaScript | Official\*         |
+| [Guilded.JS](https://github.com/guildedjs/guilded.js)      | JavaScript | Official\*         |
 | [Guilded.NET](https://github.com/Guilded-NET/Guilded.NET)  | C#         | Official\*         |
-| [guilded.py](https://github.com/shayypy/guilded.py)        | Python     | Client, Official\* |
+| [Guilded.PY](https://github.com/shayypy/guilded.py)        | Python     | Client, Official\* |
 | [Guilded.TS](https://github.com/guildedts/guilded.ts)      | TypeScript | Official\*         |
 | [Guilded4J](https://github.com/MCUmbrella/Guilded4J)       | Java       | Official\*         |
 | [Guildedeno](https://github.com/Scientific-Guy/guildedeno) | Deno       | Client             |


### PR DESCRIPTION
I figured maybe it would be nice to have all names in the library list have consistent casing in its names.

> You can also make it the opposite to make names have no upper case letters if you wish.