### PR TITLE
game name typo

### DIFF
--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -136,7 +136,7 @@ If you want to use this list in your application, feel free to grab it in [JSON 
 | 101500 | Final Fantasy XIV: Shadowbringers        |
 | 101600 | Starcraft II                             |
 | 101700 | The Elder Scrolls Online                 |
-| 101800 | Team Fortress II                         |
+| 101800 | Team Fortress 2                          |
 | 101900 | Destiny                                  |
 | 102000 | Terraria                                 |
 | 102100 | Star Wars: The Old Republic              |


### PR DESCRIPTION
The TF2 game is called Team Fortress 2 and not Team Fortress II.
Yeah, this pull request sucks, but I had to correct this since it's a great game that I play.